### PR TITLE
bugfix: adding children to emotion jsx function

### DIFF
--- a/packages/emotion/src/jsx.test.tsx
+++ b/packages/emotion/src/jsx.test.tsx
@@ -87,4 +87,51 @@ describe('#jsx', () => {
       padding: 4px;
     `)
   })
+
+  it('does not render children', () => {
+    const { container } = render(
+      <SpaceTheme>
+        <div
+          // @ts-expect-error
+          css={[{ margin: '2' }, { padding: '1' }]}
+        />
+      </SpaceTheme>,
+    )
+
+    expect(container).toHaveTextContent('')
+  })
+
+  it('renders a single child', () => {
+    const { container } = render(
+      <SpaceTheme>
+        <div
+          // @ts-expect-error
+          css={[{ margin: '2' }, { padding: '1' }]}
+        >
+          <p id="test-p">A testing paragraph</p>
+        </div>
+      </SpaceTheme>,
+    )
+
+    expect(container.querySelector('#test-p')).toHaveTextContent(
+      'A testing paragraph',
+    )
+  })
+
+  it('renders multiple children', () => {
+    const { container } = render(
+      <SpaceTheme>
+        <div
+          // @ts-expect-error
+          css={[{ margin: '2' }, { padding: '1' }]}
+        >
+          <p className="test-p">First testing paragraph</p>
+
+          <p className="test-p">Second testing paragraph</p>
+        </div>
+      </SpaceTheme>,
+    )
+
+    expect(container.querySelectorAll('.test-p')).toHaveLength(2)
+  })
 })

--- a/packages/emotion/src/jsx.ts
+++ b/packages/emotion/src/jsx.ts
@@ -7,12 +7,13 @@ import { cx } from './cx'
 export const jsx: typeof emJsx = function (
   type: React.ElementType,
   props?: object,
+  ...children: React.ReactNode[]
 ) {
   if (props == null || !Object.prototype.hasOwnProperty.call(props, 'css')) {
     // @ts-expect-error
-    return React.createElement.apply(undefined, arguments)
+    return React.createElement.apply(undefined, arguments, ...children)
   }
 
   // @ts-expect-error
-  return emJsx(type, { ...props, css: cx(props.css) })
+  return emJsx(type, { ...props, css: cx(props.css) }, ...children)
 }


### PR DESCRIPTION
## Summary

A bug on the xstyled/emotion jsx API makes the children of tags with "css" props to not be rendered:
```javascript
<div css={{...}}>
  <p>A paragraph</p> // currently, this will not be rendered
</div>
```

So, this PR fixes this issue and creates some tests to ensure its stability.

## Test plan

3 tests were created:
- Empty <div css={{...}} /> does not render any content
- <div css={{...}}> with a single children renders the content
- <div css={{...}}> with multiple children renders all elements 

Before:
![image](https://user-images.githubusercontent.com/4874089/104122181-bb95c100-5343-11eb-9ccc-5cd7b1d0779f.png)

After:
![image](https://user-images.githubusercontent.com/4874089/104122149-9d2fc580-5343-11eb-9eee-c7dd51d4e87f.png)