### PR TITLE
feature: adding preflight component to emotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-typescript": "^7.12.7",
     "@emotion/jest": "^11.0.0",
     "@emotion/react": "^11.1.4",
+    "@emotion/serialize": "^1.0.0",
     "@emotion/styled": "^11.0.0",
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.2",

--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -18,4 +18,5 @@ export {
 } from '@emotion/react'
 export * from './breakpoints'
 export * from './theme'
+export * from './preflight'
 export * from '@xstyled/system'

--- a/packages/emotion/src/preflight.test.tsx
+++ b/packages/emotion/src/preflight.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, cleanup } from '@testing-library/react'
+import { Preflight } from '.'
+
+afterEach(cleanup)
+
+describe('#Preflight', () => {
+  it('renders as a null component', () => {
+    const { container } = render(<Preflight />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('outputs all styles', () => {
+    render(<Preflight />)
+
+    expect(document.querySelectorAll('style').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/emotion/src/preflight.tsx
+++ b/packages/emotion/src/preflight.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { CSSInterpolation } from '@emotion/serialize'
+import { Global, css } from '@emotion/react'
+import { createPreflight } from '@xstyled/system'
+import { useTheme } from '@xstyled/emotion'
+
+function createGlobalStyle(...styles: Array<CSSInterpolation | Function>) {
+  return function Preflight() {
+    const theme = useTheme()
+
+    // emotion does not support function interpolation so we do from our side
+    // https://github.com/emotion-js/emotion/blob/%40emotion/serialize%401.0.0/packages/serialize/src/index.js#L189
+    const parsedStyles = styles.map((style) => {
+      if (typeof style === 'function') {
+        return style({ theme })
+      }
+
+      return style
+    })
+
+    return <Global styles={css(parsedStyles)} />
+  }
+}
+
+export const Preflight = createPreflight({ createGlobalStyle })

--- a/packages/emotion/src/preflight.tsx
+++ b/packages/emotion/src/preflight.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { CSSInterpolation } from '@emotion/serialize'
 import { Global, css } from '@emotion/react'
 import { createPreflight } from '@xstyled/system'
-import { useTheme } from '@xstyled/emotion'
+import { useTheme } from './theme'
 
 function createGlobalStyle(...styles: Array<CSSInterpolation | Function>) {
   return function Preflight() {

--- a/website/pages/docs/getting-started/installation.mdx
+++ b/website/pages/docs/getting-started/installation.mdx
@@ -74,7 +74,7 @@ npm install @emotion/core @emotion/react @emotion/styled @xstyled/emotion
 
 ```js
 // App.js
-import { defaultTheme, ThemeProvider } from '@xstyled/emotion'
+import { defaultTheme, ThemeProvider, Preflight } from '@xstyled/emotion'
 
 const theme = {
   ...defaultTheme,


### PR DESCRIPTION
## Summary

The xstyled/emotion does not provide a Preflight component, like the xstyled/styled-components do.

Now we have a Preflight exported from xstyled/emotion. It utilizes the <Global> component from emotion (https://emotion.sh/docs/globals).

## Test plan

Created two tests, basically:

1) Make sure the Preflight component renders null (as, on client, it injects into the DOM)
2) Make sure the Preflight component inject styles into the DOM.
