### PR TITLE
bugfix: size 0.5 conflict fluid range

### DIFF
--- a/packages/system/src/defaultTheme.test.ts
+++ b/packages/system/src/defaultTheme.test.ts
@@ -1,0 +1,13 @@
+import { defaultTheme } from './defaultTheme'
+
+describe('#defaultTheme', () => {
+  it('checks sizes without suffix have keys greater than 1', () => {
+    Object.entries(defaultTheme.sizes).forEach(([key, value]) => {
+      const numKey = Number(key)
+
+      if (!isNaN(numKey) && value) {
+        expect(numKey).toBeGreaterThan(1)
+      }
+    })
+  })
+})

--- a/packages/system/src/defaultTheme.ts
+++ b/packages/system/src/defaultTheme.ts
@@ -63,7 +63,7 @@ const transitions: { [key: string]: string } = Object.keys(
   transitionProperties,
 ).reduce((obj, key) => {
   obj[key] = transitionProperties[key as keyof typeof transitionProperties]
-    .map(property => `${property} ${timingFunctions['ease-in-out']} 150ms`)
+    .map((property) => `${property} ${timingFunctions['ease-in-out']} 150ms`)
     .join(',')
   return obj
 }, {} as { [key: string]: string })
@@ -329,7 +329,9 @@ export const defaultTheme = {
   },
   sizes: {
     ...space,
+    0.5: undefined,
     1: undefined,
+    '0.5s': space[0.5],
     '1s': space[1],
     full: '100%',
     xs: '20rem',

--- a/packages/system/src/defaultTheme.ts
+++ b/packages/system/src/defaultTheme.ts
@@ -63,7 +63,7 @@ const transitions: { [key: string]: string } = Object.keys(
   transitionProperties,
 ).reduce((obj, key) => {
   obj[key] = transitionProperties[key as keyof typeof transitionProperties]
-    .map((property) => `${property} ${timingFunctions['ease-in-out']} 150ms`)
+    .map(property => `${property} ${timingFunctions['ease-in-out']} 150ms`)
     .join(',')
   return obj
 }, {} as { [key: string]: string })

--- a/website/pages/docs/sizing/height.mdx
+++ b/website/pages/docs/sizing/height.mdx
@@ -44,7 +44,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
       alignItems="flex-end"
       mx="auto"
     >
-      {['1s', 8, 12, 16, 24].map((v) => (
+      {['1s', 8, 12, 16, 24].map(v => (
         <x.div
           key={v}
           spaceY={4}
@@ -91,7 +91,7 @@ Any valid value is accepted in height, numbers are converted to `px`, other unit
       alignItems="flex-end"
       mx="auto"
     >
-      {[123, '12px', '4rem', '3ex'].map((v) => (
+      {[123, '12px', '4rem', '3ex'].map(v => (
         <x.div
           key={v}
           spaceY={4}

--- a/website/pages/docs/sizing/height.mdx
+++ b/website/pages/docs/sizing/height.mdx
@@ -33,7 +33,7 @@ Use `h="100vh"` to make an element span the entire height of the viewport.
 
 ## Scaled Height
 
-All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scale `1`, you have to specify `1s`.
+All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scales between `0` and `1` due to conflicting with fluid range. You have to add a suffix `s` to target values from theme, like `0.5` becomes `0.5s` and `1` becomes `1s`.
 
 ```jsx preview color=light-blue
 <>
@@ -44,7 +44,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
       alignItems="flex-end"
       mx="auto"
     >
-      {['1s', 8, 12, 16, 24].map(v => (
+      {['1s', 8, 12, 16, 24].map((v) => (
         <x.div
           key={v}
           spaceY={4}
@@ -91,7 +91,7 @@ Any valid value is accepted in height, numbers are converted to `px`, other unit
       alignItems="flex-end"
       mx="auto"
     >
-      {[123, '12px', '4rem', '3ex'].map(v => (
+      {[123, '12px', '4rem', '3ex'].map((v) => (
         <x.div
           key={v}
           spaceY={4}

--- a/website/pages/docs/sizing/max-height.mdx
+++ b/website/pages/docs/sizing/max-height.mdx
@@ -28,7 +28,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
       alignItems="flex-end"
       mx="auto"
     >
-      {['1s', 8, 12, 16, 24].map((v) => (
+      {['1s', 8, 12, 16, 24].map(v => (
         <x.div
           key={v}
           display="flex"
@@ -85,7 +85,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
       alignItems="flex-end"
       mx="auto"
     >
-      {[110, '12px', '4rem', '3ex'].map((v) => (
+      {[110, '12px', '4rem', '3ex'].map(v => (
         <x.div
           key={v}
           display="flex"

--- a/website/pages/docs/sizing/max-height.mdx
+++ b/website/pages/docs/sizing/max-height.mdx
@@ -17,7 +17,7 @@ Utilities for setting the maximum height of an element.
 
 ## Scaled Max-Height
 
-All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scale `1`, you have to specify `1s`.
+All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scales between `0` and `1` due to conflicting with fluid range. You have to add a suffix `s` to target values from theme, like `0.5` becomes `0.5s` and `1` becomes `1s`.
 
 ```jsx preview color=light-blue
 <>
@@ -28,7 +28,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
       alignItems="flex-end"
       mx="auto"
     >
-      {['1s', 8, 12, 16, 24].map(v => (
+      {['1s', 8, 12, 16, 24].map((v) => (
         <x.div
           key={v}
           display="flex"
@@ -85,7 +85,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
       alignItems="flex-end"
       mx="auto"
     >
-      {[110, '12px', '4rem', '3ex'].map(v => (
+      {[110, '12px', '4rem', '3ex'].map((v) => (
         <x.div
           key={v}
           display="flex"

--- a/website/pages/docs/sizing/max-width.mdx
+++ b/website/pages/docs/sizing/max-width.mdx
@@ -17,13 +17,13 @@ Utilities for setting the maximum width of an element
 
 ## Scaled Max-Width
 
-All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scale `1`, you have to specify `1s`.
+All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scales between `0` and `1` due to conflicting with fluid range. You have to add a suffix `s` to target values from theme, like `0.5` becomes `0.5s` and `1` becomes `1s`.
 
 ```jsx preview color=light-blue
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {['1s', 8, 12, 16, 24].map(v => (
+      {['1s', 8, 12, 16, 24].map((v) => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="light-blue-600" w={24} textAlign="right">
             maxWidth={v}
@@ -68,7 +68,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {[110, '12px', '4rem', '3ex'].map(v => (
+      {[110, '12px', '4rem', '3ex'].map((v) => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="emerald-600" w={24} textAlign="right">
             maxWidth={v}

--- a/website/pages/docs/sizing/max-width.mdx
+++ b/website/pages/docs/sizing/max-width.mdx
@@ -23,7 +23,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {['1s', 8, 12, 16, 24].map((v) => (
+      {['1s', 8, 12, 16, 24].map(v => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="light-blue-600" w={24} textAlign="right">
             maxWidth={v}
@@ -68,7 +68,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {[110, '12px', '4rem', '3ex'].map((v) => (
+      {[110, '12px', '4rem', '3ex'].map(v => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="emerald-600" w={24} textAlign="right">
             maxWidth={v}

--- a/website/pages/docs/sizing/min-height.mdx
+++ b/website/pages/docs/sizing/min-height.mdx
@@ -28,7 +28,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
       alignItems="flex-end"
       mx="auto"
     >
-      {['1s', 8, 12, 16, 24].map((v) => (
+      {['1s', 8, 12, 16, 24].map(v => (
         <x.div
           key={v}
           spaceY={4}
@@ -75,7 +75,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
       alignItems="flex-end"
       mx="auto"
     >
-      {[123, '12px', '4rem', '3ex'].map((v) => (
+      {[123, '12px', '4rem', '3ex'].map(v => (
         <x.div
           key={v}
           spaceY={4}

--- a/website/pages/docs/sizing/min-height.mdx
+++ b/website/pages/docs/sizing/min-height.mdx
@@ -17,7 +17,7 @@ Utilities for setting the minimum height of an element.
 
 ## Scaled Min-Height
 
-All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scale `1`, you have to specify `1s`.
+All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scales between `0` and `1` due to conflicting with fluid range. You have to add a suffix `s` to target values from theme, like `0.5` becomes `0.5s` and `1` becomes `1s`.
 
 ```jsx preview color=light-blue
 <>
@@ -28,7 +28,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
       alignItems="flex-end"
       mx="auto"
     >
-      {['1s', 8, 12, 16, 24].map(v => (
+      {['1s', 8, 12, 16, 24].map((v) => (
         <x.div
           key={v}
           spaceY={4}
@@ -75,7 +75,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
       alignItems="flex-end"
       mx="auto"
     >
-      {[123, '12px', '4rem', '3ex'].map(v => (
+      {[123, '12px', '4rem', '3ex'].map((v) => (
         <x.div
           key={v}
           spaceY={4}

--- a/website/pages/docs/sizing/width.mdx
+++ b/website/pages/docs/sizing/width.mdx
@@ -39,7 +39,7 @@ All values specified in the `sizes` theme section are automatically applied. Not
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {['1s', 8, 12, 16, 24].map((v) => (
+      {['1s', 8, 12, 16, 24].map(v => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="light-blue-600" w={24} textAlign="right">
             w={v}
@@ -75,7 +75,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {[123, '12px', '4rem', '3ex'].map((v) => (
+      {[123, '12px', '4rem', '3ex'].map(v => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="emerald-600" w={24} textAlign="right">
             w={v}

--- a/website/pages/docs/sizing/width.mdx
+++ b/website/pages/docs/sizing/width.mdx
@@ -33,13 +33,13 @@ Use `w="100vw"` to make an element span the entire width of the viewport.
 
 ## Scaled Width
 
-All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scale `1`, you have to specify `1s`.
+All values specified in the `sizes` theme section are automatically applied. Note there is a little difference for scales between `0` and `1` due to conflicting with fluid range. You have to add a suffix `s` to target values from theme, like `0.5` becomes `0.5s` and `1` becomes `1s`.
 
 ```jsx preview color=light-blue
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {['1s', 8, 12, 16, 24].map(v => (
+      {['1s', 8, 12, 16, 24].map((v) => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="light-blue-600" w={24} textAlign="right">
             w={v}
@@ -75,7 +75,7 @@ Any valid value is accepted in width, numbers are converted to `px`, other units
 <>
   <template preview>
     <x.div display="flex" flexDirection="column" spaceY={4} mx="auto" w={64}>
-      {[123, '12px', '4rem', '3ex'].map(v => (
+      {[123, '12px', '4rem', '3ex'].map((v) => (
         <x.div key={v} display="flex" alignItems="center" spaceX={4}>
           <x.p fontSize="sm" color="emerald-600" w={24} textAlign="right">
             w={v}


### PR DESCRIPTION
## Summary

Fixes: https://github.com/gregberge/xstyled/issues/162

Any size key between 0 and 1 should have a suffix "s" so it does not conflict with fluid (%) values.
This PR adds a suffix "s" to size key 0.5 on theme so it can be targeted without conflicting with fluid (50%).

I've improved the explanation on the docs of why the suffix "s" have be used.

## Test plan

Added a test to check if all numeric keys of theme sizes are greater than 1.
