### PR TITLE
Updated incorrect `screens` key in the theme example

### DIFF
--- a/website/pages/docs/customization/theme.mdx
+++ b/website/pages/docs/customization/theme.mdx
@@ -25,7 +25,7 @@ The `screens` key allows you to customize the responsive breakpoints in your pro
 
 ```js
 export const theme = {
-  breakpoints: {
+  screens: {
     _: 0,
     sm: '640px',
     md: '768px',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
The docs seem quite useful, but could be a tad bit misleading when the text above an example says to use the key `screens` to provide responsive breakpoints, while the example below it uses a different key (`breakpoints` in this case).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
No code updated.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
