### PR TITLE
Improve: emotion createX function typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "styled-components": "5.2.1",
     "tsdx": "^0.14.0",
     "typescript": "^4.1.3"
+  },
+  "resolutions": {
+    "tsdx/typescript": "^4.1.3"
   }
 }

--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -29,7 +29,7 @@ export const createX: CreateX = <TProps extends object>(
     extend: (...generators) => createX(compose(generator, ...generators)),
   }
 
-  tags.forEach((tag) => {
+  tags.forEach(tag => {
     // @ts-ignore
     x[tag] = styled(tag, {
       shouldForwardProp: (prop: string) =>

--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -1,30 +1,35 @@
 /* eslint-disable no-continue, no-loop-func, no-cond-assign */
+import * as React from 'react'
 import { Theme } from '@emotion/react'
 import styled, { StyledComponent } from '@emotion/styled'
 import { compose, StyleGenerator } from '@xstyled/system'
 
 type JSXElementKeys = keyof JSX.IntrinsicElements
 
-const tags = Object.keys(styled)
+type JSXElements<TProps> = {
+  [Key in JSXElementKeys]: StyledComponent<
+    TProps & { as?: React.ElementType; theme?: Theme },
+    JSX.IntrinsicElements[Key]
+  >
+}
 
-export const createX = <TProps extends object>(generator: StyleGenerator) => {
-  type X<TProps extends object> = {
-    extend<TExtendProps extends object>(
-      ...generators: StyleGenerator[]
-    ): X<TExtendProps>
-  } & {
-    [Key in JSXElementKeys]: StyledComponent<
-      TProps & { as?: React.ElementType; theme?: Theme },
-      JSX.IntrinsicElements[Key]
-    >
-  }
+type CreateX = <TProps extends object>(generator: StyleGenerator) => X<TProps>
 
+export interface X<TProps extends object> extends JSXElements<TProps> {
+  extend: CreateX
+}
+
+const tags = Object.keys(styled) as JSXElementKeys[]
+
+export const createX: CreateX = <TProps extends object>(
+  generator: StyleGenerator,
+) => {
   // @ts-ignore
   const x: X<TProps> = {
     extend: (...generators) => createX(compose(generator, ...generators)),
   }
 
-  tags.forEach(tag => {
+  tags.forEach((tag) => {
     // @ts-ignore
     x[tag] = styled(tag, {
       shouldForwardProp: (prop: string) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -19352,12 +19352,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@^4.1.3:
+typescript@^3.7.3, typescript@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==


### PR DESCRIPTION
## Summary

The current @xstyled/emotion/x.d.ts file is broken due to this issue on typescript:
https://github.com/microsoft/TypeScript/issues/27171

https://unpkg.com/@xstyled/emotion@2.1.0/dist/x.d.ts
If you scroll down to very bottom, you fill find a couple of "... 100 more ..." strings

This branch focuses to improve the x.d.ts file in a way that it does not generate that massive type.

Basically, the main type responsible for generating that big d.ts file is JSX.IntrinsicElements.

## Test plan

(Check the .D.TS tab on right panel)

Simple example of the type on v2.1.0: 
https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAIigUwIYGMYINwChcwCeYycAUgMoAaA0soQM5wC8cA1vRAGbnUB0ASQB2MKMCENg6AKIAbZCGQiGeXMgAekWHHQQJ8dClQxkVFnAAUAShYA+OAG9ccHXobx1ALkfOXcANochHDivLT0DAC6APze7mJCAOZ4LgC+5g6pqi4oMACuUEJw6nipQA

Example of the changes that this branch suggests:
https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAIigUwIYGMYINwChcwCeYycAUgMoAaA0soQM5wC8cA1vRAGbnUB0ASQB2MKMCENg6AKIAbZCGQiGeAsVJUWcAN644cANodCccb1r0GAXQD8ALjgNR4gOZ4AvvmQAPSLDjoEBLw6CioMMiarAAUAJQsAHw6egFBTnDeDlE67qr6KDAArlBCGR5AA

I encourage you to build it local and check the x.d.ts file generated from @xstyled/emotion. Check that, with this new type, the autocomplete still works like it should, for example, showing all html tags when you type `x.`.

![image](https://user-images.githubusercontent.com/4874089/104946386-40bf4c80-59ba-11eb-91a0-9ca79cf83308.png)
