### PR TITLE
Update link to 'Getting Started' page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install @xstyled/styled-components styled-components
 
 Quicklinks to some of the most-visited pages:
 
-- [**Getting started**](https://xstyled.dev/docs/getting-started/)
+- [**Getting started**](https://xstyled.dev/docs/installation/)
 - [Motivation](https://xstyled.dev/docs/introduction/#story)
 
 ## Example


### PR DESCRIPTION
## Summary

A very small thing: the README link for 'Getting started' pointed to a 404 page. Pointing to `docs/installation` seems to be the most appropriate for now, unless otherwise desired. 

## Test plan

N/A
