### PR TITLE
fix(types): fix paddingBottop typo

### DIFF
--- a/packages/system/src/styles/space.ts
+++ b/packages/system/src/styles/space.ts
@@ -160,7 +160,7 @@ type PaddingBottomProp<T extends ITheme> = SystemProp<
   T
 >
 export interface PaddingBottomProps<T extends ITheme = Theme> {
-  paddingBottop?: PaddingBottomProp<T>
+  paddingBottom?: PaddingBottomProp<T>
   pb?: PaddingBottomProp<T>
 }
 export const paddingBottom = style<PaddingBottomProps>({


### PR DESCRIPTION
Fixing typo in PaddingBottomProps type. It should not affect functionality because paddingBottom prop is working properly, just types are off.
