### PR TITLE
improvement: faster shouldForwardProp

### DIFF
--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -29,12 +29,15 @@ export const createX: CreateX = <TProps extends object>(
     extend: (...generators) => createX(compose(generator, ...generators)),
   }
 
+  const propSet = new Set<string>(generator.meta.props)
+
+  const shouldForwardProp = (prop: string) =>
+    prop !== 'as' && !propSet.has(prop)
+
   tags.forEach((tag) => {
     // @ts-ignore
     x[tag] = styled(tag, {
-      shouldForwardProp: (prop: string) =>
-        prop !== 'as' && !generator.meta.props.includes(prop),
-      // @ts-ignore
+      shouldForwardProp,
     })<TProps>(() => [`&&{`, generator, `}`])
   })
 

--- a/packages/styled-components/src/createX.ts
+++ b/packages/styled-components/src/createX.ts
@@ -29,23 +29,32 @@ export const createX = <TProps extends object>(generator: StyleGenerator) => {
     extend: (...generators) => createX(compose(generator, ...generators)),
   }
 
+  const propSet = new Set<string>(generator.meta.props)
+
+  const shouldForwardProp = (
+    prop: string | number | symbol,
+    defaultValidatorFn: (prop: string | number | symbol) => boolean,
+    elementToBeCreated?: any,
+  ) => {
+    if (typeof prop === 'string' && propSet.has(prop)) {
+      return false
+    }
+    if (typeof elementToBeCreated === 'string') {
+      // We must test elementToBeCreated so we can pass through props for <x.div
+      // as={Component} />. However elementToBeCreated isn't available until
+      // styled-components 5.2.4 or 6, and in the meantime will be undefined.
+      // This means that HTML elements could get unwanted props, but ultimately
+      // this is a bug in the caller, because why are they passing unwanted
+      // props?
+      return defaultValidatorFn(prop)
+    }
+    return true
+  }
+
   tags.forEach((tag) => {
     // @ts-ignore
     x[tag] = styled(tag).withConfig({
-      shouldForwardProp: (prop, defaultValidatorFn, elementToBeCreated) => {
-        if (typeof prop === 'string' && generator.meta.props.includes(prop))
-          return false
-        // We must test elementToBeCreated so we can pass through props for
-        // <x.div as={Component} />. However elementToBeCreated isn't available
-        // until styled-components 5.2.4 or 6, and in the meantime will be
-        // undefined. This means that HTML elements could get unwanted props,
-        // but ultimately this is a bug in the caller, because why are they
-        // passing unwanted props?
-        if (typeof elementToBeCreated === 'string')
-          return defaultValidatorFn(prop)
-        return true
-      },
-      // @ts-ignore
+      shouldForwardProp,
     })<TProps>(() => [`&&{`, generator, `}`])
   })
 


### PR DESCRIPTION
## Summary

Checking `propSet.has()` takes about 1/20 the time as checking `props.includes()` for the 2500+ props in xstyled v2.

Even with a shorter list, say 100 props, it's still 1/2 the time, so this perf benefit carries over from v2 to v3.

## Test plan

I didn't test the perf difference directly with xstyled, but simple node. All times in milliseconds.

### 2500 element test

```
> words = fs.readFileSync('/usr/share/dict/words', {encoding: 'utf8'}).trim().split(/\s+/).slice(0, 2500)
> words.length
2500

> performance.mark('A'); for (let i = 0; i < 1000; i++) {words.includes('z')}; performance.measure('', 'A')
2.639519

> wordSet = new Set(words)
> performance.mark('B'); for (let i = 0; i < 1000; i++) {wordSet.has('z')}; performance.measure('', 'B')
0.106556
```

### 100 element test

```
> words = words.slice(0, 100)
> words.length
100

> performance.mark('A'); for (let i = 0; i < 1000; i++) {words.includes('z')}; performance.measure('', 'A')
0.194431

> wordSet = new Set(words)
> performance.mark('B'); for (let i = 0; i < 1000; i++) {wordSet.has('z')}; performance.measure('', 'B')
0.088844
```
