### PR TITLE
fix: styled.box with rule ordering instead of specificity

### DIFF
--- a/packages/emotion/src/createShouldForwardProp.ts
+++ b/packages/emotion/src/createShouldForwardProp.ts
@@ -1,0 +1,10 @@
+import { StyleGenerator } from '@xstyled/system'
+
+export const createShouldForwardProp = (generator: StyleGenerator) => {
+  const propSet = new Set<string>(generator.meta.props)
+
+  const shouldForwardProp = (prop: string) =>
+    prop !== 'as' && !propSet.has(prop)
+
+  return shouldForwardProp
+}

--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-continue, no-loop-func, no-cond-assign */
 import * as React from 'react'
 import { Theme } from '@emotion/react'
-import styled, { StyledComponent } from '@emotion/styled'
+import emStyled, { StyledComponent } from '@emotion/styled'
 import { compose, StyleGenerator } from '@xstyled/system'
 import { createShouldForwardProp } from './createShouldForwardProp'
+import { styledWithGenerator } from './styled'
 
 type JSXElementKeys = keyof JSX.IntrinsicElements
 
@@ -20,8 +21,6 @@ export interface X<TProps extends object> extends JSXElements<TProps> {
   extend: CreateX
 }
 
-const tags = Object.keys(styled) as JSXElementKeys[]
-
 export const createX: CreateX = <TProps extends object>(
   generator: StyleGenerator,
 ) => {
@@ -32,11 +31,9 @@ export const createX: CreateX = <TProps extends object>(
 
   const shouldForwardProp = createShouldForwardProp(generator)
 
-  tags.forEach((tag) => {
+  Object.keys(emStyled).forEach((tag) => {
     // @ts-ignore
-    x[tag] = styled(tag, {
-      shouldForwardProp,
-    })<TProps>(() => [`&&{`, generator, `}`])
+    x[tag] = styledWithGenerator(tag, { shouldForwardProp }, generator)``
   })
 
   return x

--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { Theme } from '@emotion/react'
 import styled, { StyledComponent } from '@emotion/styled'
 import { compose, StyleGenerator } from '@xstyled/system'
+import { createShouldForwardProp } from './createShouldForwardProp'
 
 type JSXElementKeys = keyof JSX.IntrinsicElements
 
@@ -29,10 +30,7 @@ export const createX: CreateX = <TProps extends object>(
     extend: (...generators) => createX(compose(generator, ...generators)),
   }
 
-  const propSet = new Set<string>(generator.meta.props)
-
-  const shouldForwardProp = (prop: string) =>
-    prop !== 'as' && !propSet.has(prop)
+  const shouldForwardProp = createShouldForwardProp(generator)
 
   tags.forEach((tag) => {
     // @ts-ignore

--- a/packages/emotion/src/styled.test.tsx
+++ b/packages/emotion/src/styled.test.tsx
@@ -184,6 +184,20 @@ describe('#styled.xxxBox', () => {
     expect(container.firstChild).toHaveStyle('margin: 4px;')
   })
 
+  it('overrides styles with props', () => {
+    const Dummy = styled.box`
+      margin: 2px;
+    `
+    const { container } = render(
+      <SpaceTheme>
+        <Dummy m={1} />
+      </SpaceTheme>,
+    )
+    expect(container.firstChild!.nodeName).toBe('DIV')
+    expect(container.firstChild).toHaveStyle('margin: 4px;')
+    expect(container.firstChild).not.toHaveStyle('margin: 2px;')
+  })
+
   it("doesn't forward attributes", () => {
     const Dummy = styled.box``
     const { container } = render(

--- a/packages/styled-components/src/createShouldForwardProp.ts
+++ b/packages/styled-components/src/createShouldForwardProp.ts
@@ -1,0 +1,28 @@
+import { StyleGenerator } from '@xstyled/system'
+
+// @ts-ignore
+export const createShouldForwardProp = (generator: StyleGenerator) => {
+  const propSet = new Set<string>(generator.meta.props)
+
+  const shouldForwardProp = (
+    prop: string | number | symbol,
+    defaultValidatorFn: (prop: string | number | symbol) => boolean,
+    elementToBeCreated?: any,
+  ) => {
+    if (typeof prop === 'string' && propSet.has(prop)) {
+      return false
+    }
+    if (typeof elementToBeCreated === 'string') {
+      // We must test elementToBeCreated so we can pass through props for <x.div
+      // as={Component} />. However elementToBeCreated isn't available until
+      // styled-components 5.2.4 or 6, and in the meantime will be undefined.
+      // This means that HTML elements could get unwanted props, but ultimately
+      // this is a bug in the caller, because why are they passing unwanted
+      // props?
+      return defaultValidatorFn(prop)
+    }
+    return true
+  }
+
+  return shouldForwardProp
+}

--- a/packages/styled-components/src/createX.ts
+++ b/packages/styled-components/src/createX.ts
@@ -1,11 +1,10 @@
 /* eslint-disable no-continue, no-loop-func, no-cond-assign */
-import styled, { StyledComponent, DefaultTheme } from 'styled-components'
+import scStyled, { StyledComponent, DefaultTheme } from 'styled-components'
 import { compose, StyleGenerator } from '@xstyled/system'
 import { createShouldForwardProp } from './createShouldForwardProp'
+import { styledWithGenerator } from './styled'
 
 type JSXElementKeys = keyof JSX.IntrinsicElements
-
-const tags = Object.keys(styled)
 
 type SafeIntrinsicComponent<T extends keyof JSX.IntrinsicElements> = (
   props: Omit<JSX.IntrinsicElements[T], 'color'>,
@@ -32,12 +31,11 @@ export const createX = <TProps extends object>(generator: StyleGenerator) => {
 
   const shouldForwardProp = createShouldForwardProp(generator)
 
-  tags.forEach((tag) => {
+  Object.keys(scStyled).forEach((tag) => {
     // @ts-ignore
-    x[tag] = styled(tag).withConfig({
+    x[tag] = styledWithGenerator(tag, generator).withConfig({
       shouldForwardProp,
-      // @ts-ignore
-    })<TProps>(() => [`&&{`, generator, `}`])
+    })``
   })
 
   return x

--- a/packages/styled-components/src/createX.ts
+++ b/packages/styled-components/src/createX.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-continue, no-loop-func, no-cond-assign */
 import styled, { StyledComponent, DefaultTheme } from 'styled-components'
 import { compose, StyleGenerator } from '@xstyled/system'
+import { createShouldForwardProp } from './createShouldForwardProp'
 
 type JSXElementKeys = keyof JSX.IntrinsicElements
 
@@ -29,27 +30,7 @@ export const createX = <TProps extends object>(generator: StyleGenerator) => {
     extend: (...generators) => createX(compose(generator, ...generators)),
   }
 
-  const propSet = new Set<string>(generator.meta.props)
-
-  const shouldForwardProp = (
-    prop: string | number | symbol,
-    defaultValidatorFn: (prop: string | number | symbol) => boolean,
-    elementToBeCreated?: any,
-  ) => {
-    if (typeof prop === 'string' && propSet.has(prop)) {
-      return false
-    }
-    if (typeof elementToBeCreated === 'string') {
-      // We must test elementToBeCreated so we can pass through props for <x.div
-      // as={Component} />. However elementToBeCreated isn't available until
-      // styled-components 5.2.4 or 6, and in the meantime will be undefined.
-      // This means that HTML elements could get unwanted props, but ultimately
-      // this is a bug in the caller, because why are they passing unwanted
-      // props?
-      return defaultValidatorFn(prop)
-    }
-    return true
-  }
+  const shouldForwardProp = createShouldForwardProp(generator)
 
   tags.forEach((tag) => {
     // @ts-ignore

--- a/packages/styled-components/src/styled.test.tsx
+++ b/packages/styled-components/src/styled.test.tsx
@@ -174,6 +174,16 @@ describe('#styled.xxxBox', () => {
     expect(container.firstChild).toHaveStyle('margin: 1px;')
   })
 
+  it('overrides styles with props', () => {
+    const Dummy = styled.box`
+      margin: 2px;
+    `
+    const { container } = render(<Dummy m={1} />)
+    expect(container.firstChild!.nodeName).toBe('DIV')
+    expect(container.firstChild).toHaveStyle('margin: 1px;')
+    expect(container.firstChild).not.toHaveStyle('margin: 2px;')
+  })
+
   it("doesn't forward attributes", () => {
     const Dummy = styled.box``
     const { container } = render(<Dummy margin={1} />)


### PR DESCRIPTION
## Summary

Fixes #240 with rule ordering instead of specificity.

<table><tr><th>INPUT</th><th>OLD OUTPUT</th><th>NEW OUTPUT</th></tr><tr><td>

```js
const Foo = styled.box`
  color: green;
`

<Foo color="red" />
```

</td><td>

```css
.foo.foo {
  color: red; /* ${system} */
}
.foo {
  color: green;
}
```

</td><td>

```css
.foo {
  color: green;
  color: red; /* ${system} */
}
```

</td></tr></table>

It works like this:

```js
styled.box = styledWithGenerator('div', system).withConfig({shouldForwardProp})
```

which applies the generator at the conclusion of the given styles, so that props can override styles:

```js
styled.box`
  color: green;
`

// is exactly the same as
styled.div.withConfig({shouldForwardProp})`
  color: green;
  ${system};
`
```

## Notes

My first attempt at this PR changed the signature of the `styled` function to add optional generators, so for styled-components it became `styled(component, ...generators)` and for emotion it became `styled(component, options, ...generators)`. But for now I think it's better to refrain from changing the signature, so instead we have a new *internal* API: `styledWithGenerator` so the existing `styled` export remains unmodified.

That also means we don't have to monkey with types.

## Test plan

Existing tests pass, and I added a couple new tests to make sure that props overriding works as expected.

I've also been using a local implementation of this same setup for a production app, and it's working well.