### PR TITLE
Add transient Props to @xstyled/emotion

### DIFF
--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -33,7 +33,7 @@ export const createX: CreateX = <TProps extends object>(
     // @ts-ignore
     x[tag] = styled(tag, {
       shouldForwardProp: (prop: string) =>
-        prop !== 'as' && !generator.meta.props.includes(prop) && !prop.startsWith('$'),
+        prop !== 'as' && !prop.startsWith('$') && !generator.meta.props.includes(prop),
       // @ts-ignore
     })<TProps>(() => [`&&{`, generator, `}`])
   })

--- a/packages/emotion/src/createX.ts
+++ b/packages/emotion/src/createX.ts
@@ -33,7 +33,7 @@ export const createX: CreateX = <TProps extends object>(
     // @ts-ignore
     x[tag] = styled(tag, {
       shouldForwardProp: (prop: string) =>
-        prop !== 'as' && !generator.meta.props.includes(prop),
+        prop !== 'as' && !generator.meta.props.includes(prop) && !prop.startsWith('$'),
       // @ts-ignore
     })<TProps>(() => [`&&{`, generator, `}`])
   })

--- a/packages/emotion/src/styled.test.tsx
+++ b/packages/emotion/src/styled.test.tsx
@@ -210,6 +210,16 @@ describe('#styled.xxxBox', () => {
     expect(container.firstChild).not.toHaveAttribute('margin')
   })
 
+  it("doesn't forward theme", () => {
+    const Dummy = styled.box``
+    const { container } = render(
+      <SpaceTheme>
+        <Dummy />
+      </SpaceTheme>,
+    )
+    expect(container.firstChild).not.toHaveAttribute('theme')
+  })
+
   it('supports as prop', () => {
     const Dummy = styled.divBox``
     // This is not supported by Emotion

--- a/packages/emotion/src/styled.test.tsx
+++ b/packages/emotion/src/styled.test.tsx
@@ -151,6 +151,20 @@ describe('#styled', () => {
     const { container } = render(<Dummy color="lemonchiffon" />)
     expect(container.firstChild).not.toHaveAttribute('color', 'lemonchiffon')
   })
+
+  it('should not pass props that are invalid html attributes', () => {
+    // https://emotion.sh/docs/styled#customizing-prop-forwarding
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn())
+    const Dummy = styled.box({})
+    
+    // @ts-ignore
+    const { container } = render(<Dummy $dark={false} />)
+
+    expect(container.firstChild).not.toHaveAttribute('$dark', false)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
 })
 
 describe('#styled.xxx', () => {

--- a/packages/emotion/src/styled.test.tsx
+++ b/packages/emotion/src/styled.test.tsx
@@ -210,16 +210,6 @@ describe('#styled.xxxBox', () => {
     expect(container.firstChild).not.toHaveAttribute('margin')
   })
 
-  it("doesn't forward theme", () => {
-    const Dummy = styled.box``
-    const { container } = render(
-      <SpaceTheme>
-        <Dummy />
-      </SpaceTheme>,
-    )
-    expect(container.firstChild).not.toHaveAttribute('theme')
-  })
-
   it('supports as prop', () => {
     const Dummy = styled.divBox``
     // This is not supported by Emotion


### PR DESCRIPTION
## Summary

Emotion allows its consumer apps to change styles based on props. [See here](https://emotion.sh/docs/styled#changing-based-on-props). By default, emotion would prevent invalid props from being rendered to the DOM element but since xstyled is overriding the "shouldForwardProp" this functionally is being removed. 

Styled-components handle this by prefixing the prop name with a dollar sign $.  [Transient Props](https://styled-components.com/docs/api)

Do you see any downside or conflict by doing something this? @agriffis @gregberge 

## Test plan

![image](https://user-images.githubusercontent.com/6037236/116230110-8cbb2380-a757-11eb-9228-d106437eb170.png)

My [previous PR](https://github.com/gregberge/xstyled/pull/231) was causing some issues with the "as" so this is why I just remove the ones with the $.