### PR TITLE
Add overscrollbehavior xy

### DIFF
--- a/packages/system/src/styles/layout.ts
+++ b/packages/system/src/styles/layout.ts
@@ -157,6 +157,20 @@ export const overscrollBehavior = style<OverscrollBehaviorProps>({
   prop: 'overscrollBehavior',
 })
 
+export interface OverscrollBehaviorXProps<T extends ITheme = Theme> {
+  overscrollBehaviorX?: SystemProp<CSS.Property.OverscrollBehaviorX, T>
+}
+export const overscrollBehaviorX = style<OverscrollBehaviorXProps>({
+  prop: 'overscrollBehaviorX',
+})
+
+export interface OverscrollBehaviorYProps<T extends ITheme = Theme> {
+  overscrollBehaviorY?: SystemProp<CSS.Property.OverscrollBehaviorY, T>
+}
+export const overscrollBehaviorY = style<OverscrollBehaviorYProps>({
+  prop: 'overscrollBehaviorY',
+})
+
 export interface ObjectFitProps<T extends ITheme = Theme> {
   objectFit?: SystemProp<CSS.Property.ObjectFit, T>
 }
@@ -180,6 +194,8 @@ export interface LayoutProps<T extends ITheme = Theme>
     LeftProps<T>,
     VisibilityProps<T>,
     OverscrollBehaviorProps<T>,
+    OverscrollBehaviorXProps<T>,
+    OverscrollBehaviorYProps<T>,
     ObjectFitProps<T> {}
 export const layout = compose<LayoutProps>(
   boxSizing,
@@ -197,5 +213,7 @@ export const layout = compose<LayoutProps>(
   left,
   visibility,
   overscrollBehavior,
+  overscrollBehaviorX,
+  overscrollBehaviorY,
   objectFit,
 )

--- a/website/pages/docs/layout/overscroll-behavior.mdx
+++ b/website/pages/docs/layout/overscroll-behavior.mdx
@@ -10,9 +10,11 @@ Utilities for controlling how the browser behaves when reaching the boundary of 
 
 <carbon-ad />
 
-| React props                    | CSS Properties                    |
-| ------------------------------ | --------------------------------- |
-| `overscrollBehavior={keyword}` | `overscroll-behavior: {keyword};` |
+| React props                     | CSS Properties                      |
+| ------------------------------- | ----------------------------------- |
+| `overscrollBehavior={keyword}`  | `overscroll-behavior: {keyword};`   |
+| `overscrollBehaviorX={keyword}` | `overscroll-behavior-x: {keyword};` |
+| `overscrollBehaviorY={keyword}` | `overscroll-behavior-y: {keyword};` |
 
 ## Auto
 
@@ -102,7 +104,7 @@ Use `overscrollBehavior="contain"` to prevent scrolling in the target area from 
 </>
 ```
 
-## Contain
+## None
 
 Use `overscrollBehavior="none"` to prevent scrolling in the target area from triggering scrolling in the parent element, and also prevent "bounce" effects when scrolling past the end of the container.
 
@@ -111,6 +113,270 @@ Use `overscrollBehavior="none"` to prevent scrolling in the target area from tri
   <template preview>
     <x.div
       overscrollBehavior="none"
+      overflow="auto"
+      h={32}
+      bg="amber-200"
+      color="amber-500"
+      px={6}
+      py={4}
+      fontWeight="medium"
+      fontFamily="Flow"
+      borderRadius="lg"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
+        rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
+        et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
+        hendrerit lectus volutpat eget. In porttitor tincidunt egestas.
+        Pellentesque laoreet ligula at est vulputate facilisis. Etiam tristique
+        justo ut odio placerat ornare. Cras bibendum, orci at ornare tincidunt,
+        lacus nunc gravida enim, sit amet euismod nunc lectus in lectus. Ut
+        dictum nulla et arcu aliquet ornare. Aliquam et dapibus lectus. Aenean
+        mattis elit mi, sed ultricies augue consectetur id. Sed id magna
+        malesuada, luctus urna a, bibendum tortor. Cras cursus cursus ex. Nulla
+        fringilla elit vitae imperdiet scelerisque. Donec ac sem eu diam
+        convallis mollis a sed leo. Proin congue augue turpis, eget rutrum dolor
+        ultricies non. Nulla blandit venenatis dapibus. Sed tincidunt mollis
+        elit, quis suscipit nibh eleifend quis. Donec ex lorem, auctor eu rutrum
+        in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
+        tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
+        luctus scelerisque leo fringilla vel.
+      </p>
+    </x.div>
+  </template>
+  <x.div overscrollBehavior="none">Lorem ipsum dolor sit amet...</x.div>
+</>
+```
+
+## Horizontally scroll parent at child boundary
+
+Use `overscrollBehaviorX="auto"` to make it possible for the user to continue scrolling horizontally within a parent scroll area when they reach the boundary of the primary scroll area.
+
+```jsx preview color=emerald
+<>
+  <template preview>
+    <x.div
+      overscrollBehaviorX="auto"
+      overflow="auto"
+      h={32}
+      bg="emerald-200"
+      color="emerald-500"
+      px={6}
+      py={4}
+      fontWeight="medium"
+      fontFamily="Flow"
+      borderRadius="lg"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
+        rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
+        et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
+        hendrerit lectus volutpat eget. In porttitor tincidunt egestas.
+        Pellentesque laoreet ligula at est vulputate facilisis. Etiam tristique
+        justo ut odio placerat ornare. Cras bibendum, orci at ornare tincidunt,
+        lacus nunc gravida enim, sit amet euismod nunc lectus in lectus. Ut
+        dictum nulla et arcu aliquet ornare. Aliquam et dapibus lectus. Aenean
+        mattis elit mi, sed ultricies augue consectetur id. Sed id magna
+        malesuada, luctus urna a, bibendum tortor. Cras cursus cursus ex. Nulla
+        fringilla elit vitae imperdiet scelerisque. Donec ac sem eu diam
+        convallis mollis a sed leo. Proin congue augue turpis, eget rutrum dolor
+        ultricies non. Nulla blandit venenatis dapibus. Sed tincidunt mollis
+        elit, quis suscipit nibh eleifend quis. Donec ex lorem, auctor eu rutrum
+        in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
+        tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
+        luctus scelerisque leo fringilla vel.
+      </p>
+    </x.div>
+  </template>
+  <x.div overscrollBehavior="auto">Lorem ipsum dolor sit amet...</x.div>
+</>
+```
+
+## Prevent horizontal scroll with bounce
+
+Use `overscrollBehaviorX="contain"` to prevent horizontal scrolling in the target area from triggering scrolling in the parent element, but preserve "bounce" effects when horizontally scrolling past the end of the container in operating systems that support it.
+
+```jsx preview color=light-blue
+<>
+  <template preview>
+    <x.div
+      overscrollBehaviorX="contain"
+      overflow="auto"
+      h={32}
+      bg="light-blue-200"
+      color="light-blue-500"
+      px={6}
+      py={4}
+      fontWeight="medium"
+      fontFamily="Flow"
+      borderRadius="lg"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
+        rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
+        et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
+        hendrerit lectus volutpat eget. In porttitor tincidunt egestas.
+        Pellentesque laoreet ligula at est vulputate facilisis. Etiam tristique
+        justo ut odio placerat ornare. Cras bibendum, orci at ornare tincidunt,
+        lacus nunc gravida enim, sit amet euismod nunc lectus in lectus. Ut
+        dictum nulla et arcu aliquet ornare. Aliquam et dapibus lectus. Aenean
+        mattis elit mi, sed ultricies augue consectetur id. Sed id magna
+        malesuada, luctus urna a, bibendum tortor. Cras cursus cursus ex. Nulla
+        fringilla elit vitae imperdiet scelerisque. Donec ac sem eu diam
+        convallis mollis a sed leo. Proin congue augue turpis, eget rutrum dolor
+        ultricies non. Nulla blandit venenatis dapibus. Sed tincidunt mollis
+        elit, quis suscipit nibh eleifend quis. Donec ex lorem, auctor eu rutrum
+        in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
+        tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
+        luctus scelerisque leo fringilla vel.
+      </p>
+    </x.div>
+  </template>
+  <x.div overscrollBehavior="contain">Lorem ipsum dolor sit amet...</x.div>
+</>
+```
+
+## None
+
+Use `overscrollBehaviorX="none"` to prevent horizontal scrolling in the target area from triggering horizontal scrolling in the parent element, and also prevent "bounce" effects when scrolling horizontally past the end of the container.
+
+```jsx preview color=amber
+<>
+  <template preview>
+    <x.div
+      overscrollBehaviorX="none"
+      overflow="auto"
+      h={32}
+      bg="amber-200"
+      color="amber-500"
+      px={6}
+      py={4}
+      fontWeight="medium"
+      fontFamily="Flow"
+      borderRadius="lg"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
+        rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
+        et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
+        hendrerit lectus volutpat eget. In porttitor tincidunt egestas.
+        Pellentesque laoreet ligula at est vulputate facilisis. Etiam tristique
+        justo ut odio placerat ornare. Cras bibendum, orci at ornare tincidunt,
+        lacus nunc gravida enim, sit amet euismod nunc lectus in lectus. Ut
+        dictum nulla et arcu aliquet ornare. Aliquam et dapibus lectus. Aenean
+        mattis elit mi, sed ultricies augue consectetur id. Sed id magna
+        malesuada, luctus urna a, bibendum tortor. Cras cursus cursus ex. Nulla
+        fringilla elit vitae imperdiet scelerisque. Donec ac sem eu diam
+        convallis mollis a sed leo. Proin congue augue turpis, eget rutrum dolor
+        ultricies non. Nulla blandit venenatis dapibus. Sed tincidunt mollis
+        elit, quis suscipit nibh eleifend quis. Donec ex lorem, auctor eu rutrum
+        in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
+        tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
+        luctus scelerisque leo fringilla vel.
+      </p>
+    </x.div>
+  </template>
+  <x.div overscrollBehavior="none">Lorem ipsum dolor sit amet...</x.div>
+</>
+```
+
+## Vertically scroll parent at child boundary
+
+Use `overscrollBehaviorY="auto"` to make it possible for the user to continue scrolling vertically within a parent scroll area when they reach the vertical boundary of the primary scroll area.
+
+```jsx preview color=emerald
+<>
+  <template preview>
+    <x.div
+      overscrollBehaviorY="auto"
+      overflow="auto"
+      h={32}
+      bg="emerald-200"
+      color="emerald-500"
+      px={6}
+      py={4}
+      fontWeight="medium"
+      fontFamily="Flow"
+      borderRadius="lg"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
+        rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
+        et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
+        hendrerit lectus volutpat eget. In porttitor tincidunt egestas.
+        Pellentesque laoreet ligula at est vulputate facilisis. Etiam tristique
+        justo ut odio placerat ornare. Cras bibendum, orci at ornare tincidunt,
+        lacus nunc gravida enim, sit amet euismod nunc lectus in lectus. Ut
+        dictum nulla et arcu aliquet ornare. Aliquam et dapibus lectus. Aenean
+        mattis elit mi, sed ultricies augue consectetur id. Sed id magna
+        malesuada, luctus urna a, bibendum tortor. Cras cursus cursus ex. Nulla
+        fringilla elit vitae imperdiet scelerisque. Donec ac sem eu diam
+        convallis mollis a sed leo. Proin congue augue turpis, eget rutrum dolor
+        ultricies non. Nulla blandit venenatis dapibus. Sed tincidunt mollis
+        elit, quis suscipit nibh eleifend quis. Donec ex lorem, auctor eu rutrum
+        in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
+        tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
+        luctus scelerisque leo fringilla vel.
+      </p>
+    </x.div>
+  </template>
+  <x.div overscrollBehavior="auto">Lorem ipsum dolor sit amet...</x.div>
+</>
+```
+
+## Prevent vertical scroll with bounce
+
+Use `overscrollBehaviorY="contain"` to prevent vertical scrolling in the target area from triggering vertical scrolling in the parent element, but preserve "bounce" effects when vertically scrolling past the end of the container in operating systems that support it.
+
+```jsx preview color=light-blue
+<>
+  <template preview>
+    <x.div
+      overscrollBehaviorX="contain"
+      overflow="auto"
+      h={32}
+      bg="light-blue-200"
+      color="light-blue-500"
+      px={6}
+      py={4}
+      fontWeight="medium"
+      fontFamily="Flow"
+      borderRadius="lg"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
+        rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
+        et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
+        hendrerit lectus volutpat eget. In porttitor tincidunt egestas.
+        Pellentesque laoreet ligula at est vulputate facilisis. Etiam tristique
+        justo ut odio placerat ornare. Cras bibendum, orci at ornare tincidunt,
+        lacus nunc gravida enim, sit amet euismod nunc lectus in lectus. Ut
+        dictum nulla et arcu aliquet ornare. Aliquam et dapibus lectus. Aenean
+        mattis elit mi, sed ultricies augue consectetur id. Sed id magna
+        malesuada, luctus urna a, bibendum tortor. Cras cursus cursus ex. Nulla
+        fringilla elit vitae imperdiet scelerisque. Donec ac sem eu diam
+        convallis mollis a sed leo. Proin congue augue turpis, eget rutrum dolor
+        ultricies non. Nulla blandit venenatis dapibus. Sed tincidunt mollis
+        elit, quis suscipit nibh eleifend quis. Donec ex lorem, auctor eu rutrum
+        in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
+        tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
+        luctus scelerisque leo fringilla vel.
+      </p>
+    </x.div>
+  </template>
+  <x.div overscrollBehavior="contain">Lorem ipsum dolor sit amet...</x.div>
+</>
+```
+
+## None
+
+Use `overscrollBehaviorY="none"` to prevent vertical scrolling in the target area from triggering vertical scrolling in the parent element, and also prevent "bounce" effects when scrolling vertically past the end of the container.
+
+```jsx preview color=amber
+<>
+  <template preview>
+    <x.div
+      overscrollBehaviorY="none"
       overflow="auto"
       h={32}
       bg="amber-200"

--- a/website/pages/docs/layout/overscroll-behavior.mdx
+++ b/website/pages/docs/layout/overscroll-behavior.mdx
@@ -159,6 +159,7 @@ Use `overscrollBehaviorX="auto"` to make it possible for the user to continue sc
       overscrollBehaviorX="auto"
       overflow="auto"
       h={32}
+      w="100%"
       bg="emerald-200"
       color="emerald-500"
       px={6}
@@ -167,7 +168,7 @@ Use `overscrollBehaviorX="auto"` to make it possible for the user to continue sc
       fontFamily="Flow"
       borderRadius="lg"
     >
-      <p>
+      <x.p w="200%">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
         rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
         et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
@@ -185,7 +186,7 @@ Use `overscrollBehaviorX="auto"` to make it possible for the user to continue sc
         in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
         tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
         luctus scelerisque leo fringilla vel.
-      </p>
+      </x.p>
     </x.div>
   </template>
   <x.div overscrollBehavior="auto">Lorem ipsum dolor sit amet...</x.div>
@@ -211,7 +212,7 @@ Use `overscrollBehaviorX="contain"` to prevent horizontal scrolling in the targe
       fontFamily="Flow"
       borderRadius="lg"
     >
-      <p>
+      <x.p w="200%">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
         rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
         et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
@@ -229,7 +230,7 @@ Use `overscrollBehaviorX="contain"` to prevent horizontal scrolling in the targe
         in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
         tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
         luctus scelerisque leo fringilla vel.
-      </p>
+      </x.p>
     </x.div>
   </template>
   <x.div overscrollBehavior="contain">Lorem ipsum dolor sit amet...</x.div>
@@ -255,7 +256,7 @@ Use `overscrollBehaviorX="none"` to prevent horizontal scrolling in the target a
       fontFamily="Flow"
       borderRadius="lg"
     >
-      <p>
+      <x.p w="200%">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend
         rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum
         et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae
@@ -273,7 +274,7 @@ Use `overscrollBehaviorX="none"` to prevent horizontal scrolling in the target a
         in, blandit id dolor. Nulla molestie arcu turpis. In id felis vulputate,
         tempor massa eget, malesuada mauris. Quisque fringilla consequat metus,
         luctus scelerisque leo fringilla vel.
-      </p>
+      </x.p>
     </x.div>
   </template>
   <x.div overscrollBehavior="none">Lorem ipsum dolor sit amet...</x.div>
@@ -332,7 +333,7 @@ Use `overscrollBehaviorY="contain"` to prevent vertical scrolling in the target 
 <>
   <template preview>
     <x.div
-      overscrollBehaviorX="contain"
+      overscrollBehaviorY="contain"
       overflow="auto"
       h={32}
       bg="light-blue-200"

--- a/website/pages/docs/layout/overscroll-behavior.mdx
+++ b/website/pages/docs/layout/overscroll-behavior.mdx
@@ -148,7 +148,7 @@ Use `overscrollBehavior="none"` to prevent scrolling in the target area from tri
 </>
 ```
 
-## Horizontally scroll parent at child boundary
+## Auto horizontal
 
 Use `overscrollBehaviorX="auto"` to make it possible for the user to continue scrolling horizontally within a parent scroll area when they reach the boundary of the primary scroll area.
 
@@ -192,7 +192,7 @@ Use `overscrollBehaviorX="auto"` to make it possible for the user to continue sc
 </>
 ```
 
-## Prevent horizontal scroll with bounce
+## Contain horizontal
 
 Use `overscrollBehaviorX="contain"` to prevent horizontal scrolling in the target area from triggering scrolling in the parent element, but preserve "bounce" effects when horizontally scrolling past the end of the container in operating systems that support it.
 
@@ -236,7 +236,7 @@ Use `overscrollBehaviorX="contain"` to prevent horizontal scrolling in the targe
 </>
 ```
 
-## None
+## None horizontal
 
 Use `overscrollBehaviorX="none"` to prevent horizontal scrolling in the target area from triggering horizontal scrolling in the parent element, and also prevent "bounce" effects when scrolling horizontally past the end of the container.
 
@@ -280,7 +280,7 @@ Use `overscrollBehaviorX="none"` to prevent horizontal scrolling in the target a
 </>
 ```
 
-## Vertically scroll parent at child boundary
+## Auto vertical
 
 Use `overscrollBehaviorY="auto"` to make it possible for the user to continue scrolling vertically within a parent scroll area when they reach the vertical boundary of the primary scroll area.
 
@@ -324,7 +324,7 @@ Use `overscrollBehaviorY="auto"` to make it possible for the user to continue sc
 </>
 ```
 
-## Prevent vertical scroll with bounce
+## Contain vertical
 
 Use `overscrollBehaviorY="contain"` to prevent vertical scrolling in the target area from triggering vertical scrolling in the parent element, but preserve "bounce" effects when vertically scrolling past the end of the container in operating systems that support it.
 
@@ -368,7 +368,7 @@ Use `overscrollBehaviorY="contain"` to prevent vertical scrolling in the target 
 </>
 ```
 
-## None
+## None vertical
 
 Use `overscrollBehaviorY="none"` to prevent vertical scrolling in the target area from triggering vertical scrolling in the parent element, and also prevent "bounce" effects when scrolling vertically past the end of the container.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes #268 

This adds `overscrollBehaviorX`, `overscrollBehaviorY`, the associated docs for these new props, and one typo fix on the `/docs/overscroll-behavior/` page. 

**Changes:**

- Adds `overscrollBehaviorX` to layout
- Adds `overscrollBehaviorY` to layout
- Adds docs for `overscrollBehaviorX` and `overscrollBehaviorY` to `/docs/overscroll-behavior`
- Fixes typo on `/docs/overscroll-behavior` where "Contain" is the section heading twice, instead of "Contain" and then "None"

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
This is a small change, please see `packages/system/src/styles/layout.ts`: added the same code as `overscrollBehavior` but for `overscrollBehaviorX` and `overscrollBehaviorY`.

Successful website build:
<img width="1438" alt="website_build_output" src="https://user-images.githubusercontent.com/22606045/120120017-75a99000-c160-11eb-90d2-acddb18ff8e2.png">

Successful website video:

https://user-images.githubusercontent.com/22606045/120120213-78f14b80-c161-11eb-9049-792ed1e8eaf0.mov



Successful package build:
<img width="1438" alt="package_build_output" src="https://user-images.githubusercontent.com/22606045/120120040-983ba900-c160-11eb-8001-6d839c90881c.png">

Successful package test:
<img width="1438" alt="package_test_output" src="https://user-images.githubusercontent.com/22606045/120120081-bdc8b280-c160-11eb-96d1-ce8d1b1e6553.png">

Successful package lint (note there are 57 warnings, these warnings exist prior to this PR):
<img width="1438" alt="package_lint_output" src="https://user-images.githubusercontent.com/22606045/120120122-ff595d80-c160-11eb-8241-a7ece0c0fbc6.png">



