### PR TITLE
fix: styled components module name

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "main": "dist/index.js",
-  "module": "dist/styled-components.esm.js",
+  "module": "dist/index.esm.js",
   "typings": "dist/index.d.ts",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Hi, this should fix the problem with importing '@xstyled/styled-components' using [Snowpack](https://www.snowpack.dev/).

Currently `xstyled` is unusable and iam getting following build time error:

```
[snowpack] Cannot find module '/Users/bartosz/dev/market/ui/node_modules/@xstyled/styled-components/dist/styled-components.esm.js' from '/Users/bartosz/dev/market/ui/node_modules/snowpack/lib'
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
