### PR TITLE
Add importMap to the babel plugin

### DIFF
--- a/packages/babel-preset-emotion-css-prop/src/index.ts
+++ b/packages/babel-preset-emotion-css-prop/src/index.ts
@@ -19,6 +19,7 @@ export default (
     sourceMap,
     autoLabel,
     labelFormat,
+    importMap,
     instances = [],
     ...options
   } = {},
@@ -40,6 +41,7 @@ export default (
           sourceMap,
           autoLabel,
           labelFormat,
+          importMap,
           instances: ['@xstyled/emotion', ...instances],
           cssPropOptimization: true,
         },

--- a/website/pages/docs/getting-started/migrate-from-emotion.mdx
+++ b/website/pages/docs/getting-started/migrate-from-emotion.mdx
@@ -221,29 +221,26 @@ To avoid the `/** @jsx jsx */` you can use `@xstyled/babel-preset-emotion-css-pr
 
 You may want to use [Emotion Babel plugin](https://emotion.sh/docs/babel) for minification of styles, dead code elimination, components as selectors, and a nicer debugging experience.
 
-You have to specify xstyled inside the `importMap`:
-
 **.babelrc**
 
 ```js
 {
   ...,
-  "plugins": [
+  "presets": [
     [
-      "@emotion/babel-plugin",
+      "@xstyled/babel-preset-emotion-css-prop",
       {
-        "importMap": {
-          "@xstyled/emotion": {
-            "default": {
-              "canonicalImport": ["@emotion/styled", "default"]
-            }
-          }
-        }
+        // @emotion/babel-plugin options
+        // https://emotion.sh/docs/@emotion/babel-plugin
       }
     ]
   ]
 }
 ```
+
+Note: `importMap` has some known issues coming from Emotion side
+- [Emotion not compatible with styled.box](https://github.com/gregberge/xstyled/issues/286)
+- [CSS prop doesnt have access to the theme](https://github.com/gregberge/xstyled/issues/285)
 
 ### Difference in `css` prop usage
 


### PR DESCRIPTION
Im just adding the [importMap](https://emotion.sh/docs/@emotion/babel-plugin#importmap) option to the babel plugin.
Although it does not really fix these issues https://github.com/gregberge/xstyled/issues/285 and https://github.com/gregberge/xstyled/issues/286, it is still useful in case you want to walk around this other one https://github.com/emotion-js/emotion/issues/2413 😅