### PR TITLE
Fix wrong type for ThemeVariants

### DIFF
--- a/packages/system/src/types.ts
+++ b/packages/system/src/types.ts
@@ -71,7 +71,7 @@ export type ThemeStates<T extends ITheme> = T extends {
   ? T['states']
   : unknown
 
-export type ThemeVariants<T extends ITheme> = ThemeScreens<T> & ThemeStates<T>
+export type ThemeVariants<T extends ITheme> = ThemeScreens<T> & Omit<ThemeStates<T>, '_'>
 
 export type ThemeProp<TType, TTheme extends ITheme> = {
   [P in keyof ThemeVariants<TTheme>]?: TType | ThemeProp<TType, TTheme>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Currently, auto-completion for responsive and states utility does not work. This is due to an error in the ThemeVariants type. The current ThemeVariants definition is `{ _: number; xs: number, ... } | { _: null; hover: string; ... }`, which is actually treated as `never` . To fix this, it is necessary to remove the inconsistency of `_` and join them with `&` .

Original:

![image](https://user-images.githubusercontent.com/623449/131167955-5dd40d89-2112-4f5d-a269-c3263a49227a.png)

FIxed:

![image](https://user-images.githubusercontent.com/623449/131167923-87893938-d54d-4621-97f4-2c4219921426.png)

