### PR TITLE
feat(typings): assemble deep paths for autocompletion

### DIFF
--- a/packages/system/src/types.ts
+++ b/packages/system/src/types.ts
@@ -114,9 +114,16 @@ export interface TransformValue {
   ): CSSScalar
 }
 
-export type ThemeNamespaceValue<K extends string, T extends ITheme> =
-  | NamespaceType<T[K]>
-  | {}
+declare type SynthesizedPath<T extends Theme> = {
+  [P in keyof T]: T[P] extends ITheme
+    ? `${string & P}` | `${string & P}.${SynthesizedPath<T[P]>}`
+    : `${string & P}`
+}[T extends any[] ? number & keyof T : keyof T]
+
+export type ThemeNamespaceValue<
+  K extends string,
+  T extends ITheme,
+> = SynthesizedPath<T[K]>
 
 export interface ThemeGetter<T = any> {
   (value: T, defaultValue?: CSSScalar): (props: Props<Theme>) => CSSScalar


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Fixes #308 

## Summary

This change leverages TS 4.1+ template literal types to enable deep path autocomplete for theme values.

For a theme like this:

```ts
const theme = {
  colors: {
    brandGreen: '#2B968F',
    uiButton: {
      _: '#FF0',
      hover: '#F00',
    }
  }
} as const
```

Instead of just receiving `'brandGreen' | 'uiButton'` as an autocomplete option for color props, `'uiButton._' | 'uiButton.hover'` would also be surfaced.

## Test plan

Some beta testing is probably warranted.
