### PR TITLE
fix(types): fix emotion createGlobalStyle type def

### DIFF
--- a/packages/emotion/src/createCreateGlobalStyle.tsx
+++ b/packages/emotion/src/createCreateGlobalStyle.tsx
@@ -4,8 +4,8 @@ import { Global, useTheme } from '@emotion/react'
 import { StyleGenerator } from '@xstyled/system'
 import { createCssFunction, XCSSFunction } from './createCssFunction'
 
-export interface XCreateGlobalStyle<P extends object = {}> {
-  (...styles: Parameters<XCSSFunction>): React.FC<P>
+export interface XCreateGlobalStyle {
+  <P extends object = {}>(...styles: Parameters<XCSSFunction>): React.FC<P>
 }
 
 export const createCreateGlobalStyle = <TGen extends StyleGenerator>(


### PR DESCRIPTION
## Summary

Fix createGlobalStyle in @xstyled/emotion to work the same way as its styled-components counterpart.


```tsx
import { createGlobalStyle } from "@xstyled/emotion";

// This doesn't work
const GlobalStyle = createGlobalStyle<Props>`

...

`

import { createGlobalStyle } from "@xstyled/styled-components";

// This works as expected
const GlobalStyle = createGlobalStyle<Props>`

...

`

```
