### PR TITLE
export xstyled/packages/emotion/src/create.ts

### DIFF
--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -13,6 +13,7 @@ export * from './breakpoints'
 export * from './theme'
 export * from './preflight'
 export * from '@xstyled/system'
+export * from './create'
 
 // Create and export default system
 import { system } from '@xstyled/system'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

If you'd like to import `cssCreate` function with xstyled/emotion, `xstyled/packages/styled-components/src/create.ts` module should be exported in the index file.

## Related Issues

* https://github.com/gregberge/xstyled/issues/295
