### PR TITLE
fix: move at-rules to end of nested responsive states

### DIFF
--- a/packages/system/src/style.test.ts
+++ b/packages/system/src/style.test.ts
@@ -152,6 +152,37 @@ describe('#style', () => {
           fontFamily: 'title2',
         },
       })
+      // https://github.com/gregberge/xstyled/issues/288
+      expect(
+        JSON.stringify(
+          fontFamily({
+            fontFamily: {
+              _: { _: 'title', hover: 'title2' },
+              md: { _: 'title3', hover: 'title4' },
+            },
+            theme,
+          }),
+          null,
+          2,
+        ),
+      ).toEqual(
+        JSON.stringify(
+          {
+            fontFamily: 'title',
+            '&:hover': {
+              fontFamily: 'title2',
+            },
+            '@media (min-width: 400px)': {
+              fontFamily: 'title3',
+              '&:hover': {
+                fontFamily: 'title4',
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      )
     })
 
     it('works with breakpoints', () => {

--- a/packages/system/src/theme.ts
+++ b/packages/system/src/theme.ts
@@ -36,7 +36,20 @@ export const getVariants = <T extends Props>(props: T): PropsVariants<T> => {
   for (const value in screens) {
     medias[value] = mediaMinWidth(getBreakpointMin(screens, value))
   }
-  return { ...medias, ...states }
+  const variants = { ...medias, ...states }
+
+  // Move at-rules to the end, since they don't increase specificity by
+  // themselves but might need to override something that does.
+  // See https://github.com/gregberge/xstyled/issues/288
+  for (const [value, selector] of Object.entries(variants)) {
+    if (selector && selector.startsWith('@')) {
+      delete variants[value]
+      // @ts-ignore
+      variants[value] = selector
+    }
+  }
+
+  return variants
 }
 
 export const getCachedVariants = <T extends Props>(


### PR DESCRIPTION
## Summary

Move at-rules to the end of sorted styles, so that nested states can override. Fixes #288 

## Alternative

This _almost_ works:

```diff
-   const variants = { ...medias, ...states }
+   const variants = { ...states, ...medias }
```

but it's not enough, because `states` can contain at-rules too. The xstyled-provided `states` already does, and the developer could also supply their own, for instance with `@supports`

so instead we explicitly move at-rules to the end, similar to the way that `sortStyles` works.

## Test plan

Added a new test to ensure that rules are emitted in order. Without the code change, it fails like this:

```
 FAIL  packages/system/src/style.test.ts
  ● #style › #style › works with variants

    expect(received).toEqual(expected) // deep equality

    - Expected  - 8
    + Received  + 8

      {
        "fontFamily": "title",
    -   "&:hover": {
    +   "@media (min-width: 400px)": {
    -     "fontFamily": "title2"
    -   },
    -   "@media (min-width: 400px)": {
    +     "fontFamily": "title3",
    +     "&:hover": {
    -     "fontFamily": "title3",
    -     "&:hover": {
    +       "fontFamily": "title4"
    +     }
    +   },
    +   "&:hover": {
    -       "fontFamily": "title4"
    -     }
    +     "fontFamily": "title2"
        }
      }

      169 |           2,
      170 |         ),
    > 171 |       ).toEqual(
          |         ^
      172 |         JSON.stringify(
      173 |           {
      174 |             fontFamily: 'title',

      at Object.<anonymous> (packages/system/src/style.test.ts:171:9)

```
