### PR TITLE
fix(website): listStyleType examples

### DIFF
--- a/website/pages/docs/typography/list-style-type.mdx
+++ b/website/pages/docs/typography/list-style-type.mdx
@@ -49,19 +49,20 @@ To create custom lists, use the `listStyleType={type}` utilities.
       ))}
     </x.div>
   </template>
-  <x.ul listStyleType="disc">
+  {/* inline styles required to override smooth-doc */}
+  <x.ul listStyleType="disc" style="list-style-type: disc">
     <li>Lorem ipsum ...</li>
   </x.ul>
-  <x.ul listStyleType="decimal">
+  <x.ul listStyleType="decimal" style="list-style-type: decimal">
     <li>Lorem ipsum ...</li>
   </x.ul>
-  <x.ul listStyleType="circle">
+  <x.ul listStyleType="circle" style="list-style-type: circle">
     <li>Lorem ipsum ...</li>
   </x.ul>
-  <x.ul listStyleType="square">
+  <x.ul listStyleType="square" style="list-style-type: circle">
     <li>Lorem ipsum ...</li>
   </x.ul>
-  <x.ul listStyleType="none">
+  <x.ul listStyleType="none" style="list-style-type: none">
     <li>Lorem ipsum ...</li>
   </x.ul>
 </>


### PR DESCRIPTION
## Summary

The `listStyleType` [examples on the website](https://xstyled.dev/docs/list-style-type/#list-style-type) look like this:

![image](https://user-images.githubusercontent.com/50637/143781320-b6c5cd54-f9ee-44e9-acdb-280defc6b091.png)

The problem is that smooth-doc supplies a nested style for unordered lists, and `<x.div>` can't override it.

## Test plan

Make a PR and see if it worked :stuck_out_tongue_winking_eye: 