### PR TITLE
update documentation for dark mode state

### DIFF
--- a/website/pages/docs/core-concepts/hover-focus-and-other-states.mdx
+++ b/website/pages/docs/core-concepts/hover-focus-and-other-states.mdx
@@ -209,7 +209,7 @@ You can completely customize states in your theme:
 export const theme = {
   states: {
     firstLetter: '&::first-letter',
-    dark: '.xstyled-color-mode-dark &',
+    dark: '.xstyled-color-mode-dark &&',
   },
 }
 ```


### PR DESCRIPTION
A single ampersand refers to the static component selector which will have unintended effects when the styled-components babel plugin is also used. Double ampersand refers to an instance of the component, e.g. a specific `<x.div>` not ALL `<x.div>`.