### PR TITLE
feat: added inline variants #333

### DIFF
--- a/packages/system/src/style.test.ts
+++ b/packages/system/src/style.test.ts
@@ -109,6 +109,11 @@ describe('#style', () => {
         states: { hover: '&:hover', first: '&:first-child' },
         screens: { _: 0, md: 400 },
       }
+      expect(fontFamily({ fontFamily: { '&:empty': 'title' }, theme })).toEqual({
+        '&:empty': {
+          fontFamily: 'title',
+        },
+      })
       expect(fontFamily({ fontFamily: { hover: 'title' }, theme })).toEqual({
         '&:hover': {
           fontFamily: 'title',
@@ -161,6 +166,14 @@ describe('#style', () => {
       })
       expect(fontFamily({ fontFamily: { md: 'title' }, theme })).toEqual({
         '@media (min-width: 400px)': {
+          fontFamily: 'title',
+        },
+      })
+      expect(fontFamily({
+        fontFamily: { '@media (min-width: 355px)': 'title' },
+        theme
+      })).toEqual({
+        '@media (min-width: 355px)': {
           fontFamily: 'title',
         },
       })

--- a/packages/system/src/style.ts
+++ b/packages/system/src/style.ts
@@ -159,7 +159,7 @@ export const reduceVariants = <T extends Props>(
   for (const value in values) {
     const style = getStyle(values[value])
     if (style === null) continue
-    const state = variants[value]
+    const state = value in variants ? variants[value] : value
     if (state === undefined) continue
     if (state === null) {
       styles = merge(styles, style)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Example: `<x.div color={{ '&:empty': 'red' }}/>`

This makes it, so we fall back to `&:empty` when `theme.states['&:empty']` and `theme.breakpoints['&:empty']` is not defined,
just like we use `red` when `theme.colors.red` is not defined.

## Test plan

I added unit tests, if there are more test cases I should take a look at, let me know.
I also tried it out using x from the `styled-components` package.
