### PR TITLE
feat: add border positions style helpers

### DIFF
--- a/packages/system/src/styles/borders.test.ts
+++ b/packages/system/src/styles/borders.test.ts
@@ -69,3 +69,31 @@ describe('#ring', () => {
     })
   })
 })
+
+describe('#borderStyle', () => {
+  it('works as expected', () => {
+    expect(borders({ borderStyle: 'dashed' })).toEqual({
+      borderStyle: 'dashed',
+    })
+  })
+  it('works as expected', () => {
+    expect(borders({ borderTopStyle: 'dashed' })).toEqual({
+      borderTopStyle: 'dashed',
+    })
+  })
+  it('works as expected', () => {
+    expect(borders({ borderRightStyle: 'solid' })).toEqual({
+      borderRightStyle: 'solid',
+    })
+  })
+  it('works as expected', () => {
+    expect(borders({ borderBottomStyle: 'double' })).toEqual({
+      borderBottomStyle: 'double',
+    })
+  })
+  it('works as expected', () => {
+    expect(borders({ borderLeftStyle: 'dotted' })).toEqual({
+      borderLeftStyle: 'dotted',
+    })
+  })
+})

--- a/packages/system/src/styles/borders.ts
+++ b/packages/system/src/styles/borders.ts
@@ -201,6 +201,50 @@ export const borderStyle = style<BorderStyleProps>({
   ],
 })
 
+export interface BorderTopStyleProps<T extends ITheme = Theme> {
+  borderTopStyle?: SystemProp<
+    ThemeBorderStyle<T> | CSS.Property.BorderTopStyle,
+    T
+  >
+}
+export const borderTopStyle = style<BorderTopStyleProps>({
+  prop: 'borderTopStyle',
+  themeGet: getBorderStyle,
+})
+
+export interface BorderRightStyleProps<T extends ITheme = Theme> {
+  borderRightStyle?: SystemProp<
+    ThemeBorderStyle<T> | CSS.Property.BorderRightStyle,
+    T
+  >
+}
+export const borderRightStyle = style<BorderRightStyleProps>({
+  prop: 'borderRightStyle',
+  themeGet: getBorderStyle,
+})
+
+export interface BorderBottomStyleProps<T extends ITheme = Theme> {
+  borderBottomStyle?: SystemProp<
+    ThemeBorderStyle<T> | CSS.Property.BorderBottomStyle,
+    T
+  >
+}
+export const borderBottomStyle = style<BorderBottomStyleProps>({
+  prop: 'borderBottomStyle',
+  themeGet: getBorderStyle,
+})
+
+export interface BorderLeftStyleProps<T extends ITheme = Theme> {
+  borderLeftStyle?: SystemProp<
+    ThemeBorderStyle<T> | CSS.Property.BorderLeftStyle,
+    T
+  >
+}
+export const borderLeftStyle = style<BorderLeftStyleProps>({
+  prop: 'borderLeftStyle',
+  themeGet: getBorderStyle,
+})
+
 // Outline
 
 export interface OutlineProps<T extends ITheme = Theme> {
@@ -440,6 +484,10 @@ export const borders = compose<BordersProps>(
   borderBottomWidth,
   borderLeftWidth,
   borderStyle,
+  borderTopStyle,
+  borderRightStyle,
+  borderBottomStyle,
+  borderLeftStyle,
   borderRadius,
   outline,
   outlineColor,

--- a/website/pages/docs/borders/border-style.mdx
+++ b/website/pages/docs/borders/border-style.mdx
@@ -10,9 +10,13 @@ Utilities for controlling the style of an element's borders.
 
 <carbon-ad />
 
-| React props           | CSS Properties           |
-| --------------------- | ------------------------ |
-| `borderStyle={style}` | `border-style: {style};` |
+| React props                 | CSS Properties                  |
+| --------------------------- | ------------------------------- |
+| `borderStyle={style}`       | `border-style: {style};`        |
+| `borderTopStyle={style}`    | `border-top-style: {style};`    |
+| `borderRightStyle={style}`  | `border-right-style: {style};`  |
+| `borderBottomStyle={style}` | `border-bottom-style: {style};` |
+| `borderLeftStyle={style}`   | `border-left-style: {style};`   |
 
 ## Usage
 

--- a/website/pages/docs/borders/border-style.mdx
+++ b/website/pages/docs/borders/border-style.mdx
@@ -55,7 +55,7 @@ Use `borderStyle={style}` to control an element's border style.
 
 ## Responsive
 
-To control the border style of an element at a specific breakpoint, use responsive object notation. For example, adding the property `borderStyle={{ md: 'solid' }}` to an element would apply the `borderStyle="solid` utility at medium screen sizes and above.
+To control the border style of an element at a specific breakpoint, use responsive object notation. For example, adding the property `borderStyle={{ md: 'solid' }}` to an element would apply the `borderStyle="solid"` utility at medium screen sizes and above.
 
 ```jsx
 <x.div borderStyle={{ md: 'solid' }}>{/* ... */}</x.div>


### PR DESCRIPTION
## Summary

The properties are not taken into account :
- borderTopStyle
- borderRightStyle
- borderBottomStyle
- borderLeftStyle

## Test plan

See new tests in `packages/system/src/styles/borders.test.ts`
