### PR TITLE
impr(typing): infer automatically the typing of the generators used inside of the compose

### DIFF
--- a/packages/system/src/style.ts
+++ b/packages/system/src/style.ts
@@ -27,6 +27,7 @@ import {
   Mixin,
   StyleOptions,
   CSSOption,
+  StyleGeneratorPropsConcat,
 } from './types'
 
 let themeGetterId = 0
@@ -224,9 +225,14 @@ const sortStyles = (
   return styles
 }
 
-export const compose = <TProps = {}>(
+export function compose<TProps = {}>(
   ...generators: StyleGenerator[]
-): StyleGenerator<TProps> => {
+): StyleGenerator<TProps>
+export function compose<T extends StyleGenerator[]>(
+  ...generators: T
+): StyleGenerator<StyleGeneratorPropsConcat<T>>
+
+export function compose(...generators: any[]): any {
   let flatGenerators: StyleGenerator[] = []
 
   generators.forEach((gen) => {

--- a/packages/system/src/types.ts
+++ b/packages/system/src/types.ts
@@ -142,8 +142,10 @@ export type ThemeGetterType<T extends ThemeGetter> = T extends ThemeGetter<
   ? T
   : never
 
-export type StyleGeneratorProps<T extends object> = T extends StyleGenerator<
-  infer T
->
-  ? T
+export type StyleGeneratorProps<T> = T extends StyleGenerator<infer Props>
+  ? Props
   : never
+
+export type StyleGeneratorPropsConcat<T> = T extends [infer Head, ...infer Tail]
+  ? StyleGeneratorProps<Head> & StyleGeneratorPropsConcat<Tail>
+  : unknown


### PR DESCRIPTION
## Summary

As the title states, the goal of this MR is to infer automatically the return type of the `compose` method and also support the existing type in order not to create a breaking change in that area.

Before, in order to have the correct return type, you'd have to explicitly provide the "computed" return type:
```ts
interface GridItemProps extends GridAreaProps, GridColumnProps, GridRowProps {}
const gridItem = compose<GridItemProps>(gridArea, gridColumn, gridRow);
```

With this new change, you'd still be able to do that (like we do internally on xstyled) or you could just write the following:

```ts
const gridItem = compose(gridArea, gridColumn, gridRow);
// generated return type
// StyleGenerator<GridAreaProps<Theme> & GridColumnProps<Theme> & GridRowProps<Theme>>
```

