### PR TITLE
docs: added inline states to hover-focus-other-states page

### DIFF
--- a/website/pages/docs/core-concepts/hover-focus-and-other-states.mdx
+++ b/website/pages/docs/core-concepts/hover-focus-and-other-states.mdx
@@ -177,6 +177,39 @@ Use nested objects to combine states.
 </>
 ```
 
+## Inline states
+
+Inline your states and breakpoints, `&:hover` works just like the default theme `hover` state.
+
+```jsx preview color=indigo
+<>
+  <template preview>
+    <x.div textAlign="center">
+      <x.a
+        href="#inline-states"
+        color={{
+          '&': 'indigo-500',
+          '&:hover': 'indigo-600',
+          '&[href^="#"]': { '&': 'green-500', '&:hover': 'green-600' },
+        }}
+      >
+        Link
+      </x.a>
+    </x.div>
+  </template>
+  <x.a
+    href="#inline-states"
+    color={{
+      '&': 'indigo-500',
+      '&:hover': 'indigo-600',
+      '&[href^="#"]': { '&': 'green-500', '&:hover': 'green-600' },
+    }}
+  >
+    Link
+  </x.a>
+</>
+```
+
 ## Available states
 
 Default theme includes a set of useful states.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This is the documentation for the feature I added in #334.

## Test plan

I tested this manually.

<img width="768" alt="image" src="https://user-images.githubusercontent.com/25524993/168055508-be5009f5-bfc4-4298-aeeb-c3f05267f446.png">
