### PR TITLE
Export `XStyled` interface to resolve build errors in pnpm monorepos

### DIFF
--- a/packages/emotion/src/create.ts
+++ b/packages/emotion/src/create.ts
@@ -1,13 +1,14 @@
 import { StyleGenerator } from '@xstyled/system'
 import { createCssFunction, XCSSFunction } from './createCssFunction'
 import { createX, X } from './createX'
-import { createStyled, XStyled } from './createStyled'
+import { createStyled } from './createStyled'
 import {
   createCreateGlobalStyle,
   XCreateGlobalStyle,
 } from './createCreateGlobalStyle'
 import { createCx, Cx } from './createCx'
 import { createJsx, XJsx } from './createJsx'
+import { XStyled } from './types'
 
 interface XStyledSet<TGen extends StyleGenerator> {
   css: XCSSFunction

--- a/packages/emotion/src/createStyled.ts
+++ b/packages/emotion/src/createStyled.ts
@@ -1,10 +1,7 @@
-import * as React from 'react'
-import { CreateStyledComponent, CreateStyled } from '@emotion/styled'
-import { Theme } from '@emotion/react'
-import { StyleGenerator, StyleGeneratorProps } from '@xstyled/system'
-import { BoxElements } from '@xstyled/core'
+import { StyleGenerator } from '@xstyled/system'
 import { createCssFunction, XCSSFunction } from './createCssFunction'
 import { emStyled } from './emStyled'
+import type { XStyled } from './types';
 
 const flattenArgs = (arg: any, props: any): any => {
   if (typeof arg === 'function') return flattenArgs(arg(props), props)
@@ -36,16 +33,6 @@ const getCreateStyle = (
   }
 }
 
-type BoxStyledTags<TProps extends object> = {
-  [Tag in keyof BoxElements]: CreateStyledComponent<
-    TProps & { as?: React.ElementType; theme?: Theme },
-    JSX.IntrinsicElements[BoxElements[Tag]]
-  >
-}
-
-export interface XStyled<TGen extends StyleGenerator>
-  extends CreateStyled,
-    BoxStyledTags<StyleGeneratorProps<TGen>> {}
 
 const createShouldForwardProp = (
   generator: StyleGenerator,

--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -14,6 +14,7 @@ export * from './theme'
 export * from './preflight'
 export * from '@xstyled/system'
 export * from './create'
+export * from './types';
 
 // Create and export default system
 import { system } from '@xstyled/system'

--- a/packages/emotion/src/types.ts
+++ b/packages/emotion/src/types.ts
@@ -1,0 +1,15 @@
+import type { CreateStyledComponent, CreateStyled } from '@emotion/styled'
+import type { Theme } from '@emotion/react'
+import type { BoxElements } from '@xstyled/core'
+import type { StyleGenerator, StyleGeneratorProps } from '@xstyled/system'
+
+export type BoxStyledTags<TProps extends object> = {
+  [Tag in keyof BoxElements]: CreateStyledComponent<
+    TProps & { as?: React.ElementType; theme?: Theme },
+    JSX.IntrinsicElements[BoxElements[Tag]]
+  >
+}
+
+export interface XStyled<TGen extends StyleGenerator>
+  extends CreateStyled,
+    BoxStyledTags<StyleGeneratorProps<TGen>> {}

--- a/packages/styled-components/src/create.ts
+++ b/packages/styled-components/src/create.ts
@@ -1,13 +1,14 @@
 import { StyleGenerator } from '@xstyled/system'
 import { createCssFunction, XCSSFunction } from './createCssFunction'
 import { createX, X } from './createX'
-import { createStyled, XStyled } from './createStyled'
+import { createStyled } from './createStyled'
 import {
   createCreateGlobalStyle,
   XCreateGlobalStyle,
 } from './createCreateGlobalStyle'
+import { XStyled } from './types'
 
-interface XStyledSet<TGen extends StyleGenerator> {
+export interface XStyledSet<TGen extends StyleGenerator> {
   css: XCSSFunction
   x: X<TGen>
   styled: XStyled<TGen>

--- a/packages/styled-components/src/createStyled.ts
+++ b/packages/styled-components/src/createStyled.ts
@@ -1,15 +1,11 @@
 /* eslint-disable no-continue, no-loop-func, no-cond-assign */
 import type { ElementType } from 'react'
-import { BoxElements } from '@xstyled/core'
 import { string } from '@xstyled/util'
-import { StyleGenerator, StyleGeneratorProps, Theme } from '@xstyled/system'
-import {
-  StyledConfig,
-  ThemedBaseStyledInterface,
-  ThemedStyledFunction,
-} from 'styled-components'
+import type { StyleGenerator } from '@xstyled/system'
+import type { StyledConfig, ThemedStyledFunction } from 'styled-components'
 import { scStyled } from './scStyled'
 import { createCssFunction, XCSSFunction } from './createCssFunction'
+import { XStyled } from './types'
 
 const getCreateStyle = (
   baseCreateStyle: ThemedStyledFunction<any, any>,
@@ -25,18 +21,6 @@ const getCreateStyle = (
     getCreateStyle(baseCreateStyle.withConfig(config), css, generator)
   return createStyle
 }
-
-type BoxStyledTags<TProps extends object> = {
-  [Key in keyof BoxElements]: ThemedStyledFunction<
-    BoxElements[Key],
-    Theme,
-    TProps
-  >
-}
-
-export interface XStyled<TGen extends StyleGenerator>
-  extends ThemedBaseStyledInterface<Theme>,
-    BoxStyledTags<StyleGeneratorProps<TGen>> {}
 
 const createShouldForwardProp = (
   generator: StyleGenerator,

--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -14,6 +14,7 @@ export * from './breakpoints'
 export * from './preflight'
 export * from '@xstyled/system'
 export * from './create'
+export * from './types';
 
 // Create and export default system
 import { system } from '@xstyled/system'

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -1,0 +1,18 @@
+import type { BoxElements } from '@xstyled/core'
+import type { StyleGenerator, StyleGeneratorProps, Theme } from '@xstyled/system'
+import type {
+  ThemedBaseStyledInterface,
+  ThemedStyledFunction
+} from 'styled-components'
+
+export type BoxStyledTags<TProps extends object> = {
+  [Key in keyof BoxElements]: ThemedStyledFunction<
+    BoxElements[Key],
+    Theme,
+    TProps
+  >
+}
+
+export interface XStyled<TGen extends StyleGenerator>
+  extends ThemedBaseStyledInterface<Theme>,
+    BoxStyledTags<StyleGeneratorProps<TGen>> {}


### PR DESCRIPTION
Now this is a story all about how my life got flipped turned upside down, and I'd like to take a minute just sit right, there, I'll tell you how I fixed this nasty TypeScript error.

## Summary

I have a pnpm monorepo set up using xstyled for its UI kit components, but it doesn't build and fails on the following error:

```
src/xstyled.config.ts(27,43): error TS4023: 
Exported variable 'styled' has or is using name 'XStyled' from external module "node_modules/.pnpm/@xstyled+styled-components@3.6.0_styled-components@5.3.5/node_modules/@xstyled/styled-components/dist/index" 
but cannot be named.
```

After doing a bit of digging I found that `XStyled` is defined in the `index.d.ts` for `@xstyled/emotion` and `@xstyled/styled-components`, but it's not exported which breaks the UI kit build during the generation of `d.ts` files.

This PR adds `XStyled` (and `BoxStyledTags`) as an export for `@xstyled/emotion` and `@xstyled/styled-components`. There aren't any runtime code changes, it's just exporting already defined types.

## Test plan

I've run through the build steps of the contrib guide and works as expected. I've also got an example repo using the builds from my fork and they work ok too.

https://github.com/nerdyman/xstyled-pnpm-monorepo-ts2742

Hopefully this is up to scratch 🙏 
