### PR TITLE
Update text.mdx

### DIFF
--- a/website/pages/docs/typography/text.mdx
+++ b/website/pages/docs/typography/text.mdx
@@ -111,7 +111,7 @@ If you don't want to customize it, a set of `text` is already defined in default
 ```js
 const defaultTheme = {
   // ...
-  text: {
+  texts: {
     xs: { fontSize: 'xs', lineHeight: 'xs' },
     sm: { fontSize: 'sm', lineHeight: 'sm' },
     default: { fontSize: 'default', lineHeight: 'default' },

--- a/website/pages/docs/typography/text.mdx
+++ b/website/pages/docs/typography/text.mdx
@@ -106,12 +106,12 @@ If you'd like to customize your values for texts, use the `theme.texts` section 
   }
 ```
 
-If you don't want to customize it, a set of `fontSizes` is already defined in default theme:
+If you don't want to customize it, a set of `text` is already defined in default theme:
 
 ```js
 const defaultTheme = {
   // ...
-  fontSizes: {
+  text: {
     xs: { fontSize: 'xs', lineHeight: 'xs' },
     sm: { fontSize: 'sm', lineHeight: 'sm' },
     default: { fontSize: 'default', lineHeight: 'default' },

--- a/website/pages/docs/typography/text.mdx
+++ b/website/pages/docs/typography/text.mdx
@@ -106,7 +106,7 @@ If you'd like to customize your values for texts, use the `theme.texts` section 
   }
 ```
 
-If you don't want to customize it, a set of `text` is already defined in default theme:
+If you don't want to customize it, a set of `texts` is already defined in default theme:
 
 ```js
 const defaultTheme = {


### PR DESCRIPTION
I think `texts` is the key here not `fontSizes` as `fontSizes` in the `defaultTheme` is not an object like `texts` is.

## Summary

Fixing an doc issue with the wrong key listed in the example.

## Test plan

none - changing only docs
