### PR TITLE
Fixed: typo

### DIFF
--- a/website/partials/customizing/font-families.mdx
+++ b/website/partials/customizing/font-families.mdx
@@ -16,12 +16,12 @@ Fonts have to be specified exactly like you specify them in [CSS property `font-
 
 Learn more about customizing the default theme in the [theme customization documentation](@TODO-link).
 
-If you don't want to customize it, a set of `fontFamily` is already defined in default theme:
+If you don't want to customize it, a set of `fonts` is already defined in default theme:
 
 ```js
 const defaultTheme = {
   // ...
-  fontFamilies: {
+  fonts: {
     mono: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
     serif: `ui-serif, Georgia, Cambria, "Times New Roman", Times, serif`,
     sans: `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,


### PR DESCRIPTION
The section is `fonts` in the real file but the section example here used the wrong word.

## Summary

Fixing typo

## Test plan

none - doc change only
