### PR TITLE
perf: use map instead of weakmap

### DIFF
--- a/packages/system/src/cache.ts
+++ b/packages/system/src/cache.ts
@@ -10,16 +10,16 @@ interface ThemeCache {
   [key: string]: XCache<any>
 }
 
-const cacheSupported: boolean =
-  typeof Map !== 'undefined' && typeof WeakMap !== 'undefined'
+const cacheSupported: boolean = typeof Map !== 'undefined'
 
-const caches = cacheSupported ? new WeakMap<ITheme, ThemeCache>() : null
+const caches = cacheSupported ? new Map<string, ThemeCache>() : null
 
 const getThemeCache = (theme: ITheme): ThemeCache | null => {
   if (caches === null) return null
-  if (caches.has(theme)) return caches.get(theme) || null
+  const stringifiedTheme = JSON.stringify(theme)
+  if (caches.has(stringifiedTheme)) return caches.get(stringifiedTheme) || null
   const cache = {}
-  caches.set(theme, cache)
+  caches.set(stringifiedTheme, cache)
   return cache
 }
 


### PR DESCRIPTION
## Summary

Following this issue https://github.com/gregberge/xstyled/issues/371, use a `Map` instead of a `WeakMap` for **caches** (with a theme stringifed as key instead of theme object). This will prevent continued cache growth.

## Test plan

Check https://github.com/gregberge/xstyled/issues/371#issuecomment-1218335972
